### PR TITLE
Updated-Install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,7 @@ echo -e "\e[40;38;5;82m pip3 installed \e[0m\n"
 #==============================================================================================
 echo -e "\e[40;38;5;82m Installing subfinder \e[0m\n"
 
-GO111MODULE=on go get -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder
+go install -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest
 
 echo -e "\e[40;38;5;82m Subfinder Installed \e[0m\n"
 
@@ -82,7 +82,7 @@ chmod +x findomain-linux
 mv findomain-linux /usr/local/bin/findomain
 
 echo -e "\e[40;38;5;82m Findomain installed \e[0m\n"
-
+#General Use: 
 #==============================================================================================
 echo -e "\e[40;38;5;82m Installing sd-goo \e[0m\n"
 
@@ -114,7 +114,7 @@ echo -e "\e[40;38;5;82m amass installed \e[0m\n"
 #==============================================================================================
 echo -e "\e[40;38;5;82m Installing gauplus \e[0m\n"
 
-GO111MODULE=on go get -u -v github.com/bp0lr/gauplus
+go install github.com/bp0lr/gauplus@latest
 
 echo -e "\e[40;38;5;82m Gauplus installed \e[0m\n"
 #==============================================================================================
@@ -143,7 +143,7 @@ echo -e "\e[40;38;5;82m Installing Puredns \e[0m\n"
 cd $HOME/tools/ && git clone https://github.com/blechschmidt/massdns.git
 cd massdns && make && make install
 
-GO111MODULE=on go get github.com/d3mondev/puredns/v2
+go install github.com/d3mondev/puredns/v2@latest
 
 echo -e "\e[40;38;5;82m Puredns installed \e[0m\n"
 
@@ -155,7 +155,7 @@ chmod 755 DNScewl
 mv DNScewl /usr/local/bin/DNScewl
 
 echo -e "\e[40;38;5;82m DNSCewl installed \e[0m\n"
-
+#Gerneral Use:DNSCewl -tL targets.txt -p append.txt
 #==============================================================================================
 echo -e "\e[40;38;5;82m Installing dnsvalidator \e[0m\n"
 
@@ -164,11 +164,11 @@ cd dnsvalidator/
 python3 setup.py install
 
 echo -e "\e[40;38;5;82m DNSCewl installed \e[0m\n"
-
+#general Use: dnsvalidator -tL https://public-dns.info/nameservers.txt -threads 20 -o resolvers.txt
 #==============================================================================================
 echo -e "\e[40;38;5;82m Installing httpx \e[0m\n"
 
-GO111MODULE=on go get -v github.com/projectdiscovery/httpx/cmd/httpx
+go install -v github.com/projectdiscovery/httpx/cmd/httpx@latest
 
 echo -e "\e[40;38;5;82m httpx installed \e[0m\n"
 
@@ -182,7 +182,7 @@ echo -e "\e[40;38;5;82m Gospider installed \e[0m\n"
 #==============================================================================================
 echo -e "\e[40;38;5;82m Installing Notify \e[0m\n"
 
-GO111MODULE=on go get -v github.com/projectdiscovery/notify/cmd/notify
+go install -v github.com/projectdiscovery/notify/cmd/notify@latest
 
 echo -e "\e[40;38;5;82m Notify installed \e[0m\n"
 #==============================================================================================
@@ -239,7 +239,7 @@ echo -e "\e[40;38;5;82m Kxss installed \e[0m\n"
 #==============================================================================================
 echo -e "\e[40;38;5;82m Installing Dnsx \e[0m\n"
 
-go get -v github.com/projectdiscovery/dnsx/cmd/dnsx
+go install -v github.com/projectdiscovery/dnsx/cmd/dnsx@latest
 
 echo -e "\e[40;38;5;82m Dnsx installed \e[0m\n"
 
@@ -254,20 +254,19 @@ echo -e "\e[40;38;5;82m JQ installed \e[0m\n"
 echo -e "\e[40;38;5;82m Installing Naabu \e[0m\n"
 
 sudo apt install -y libpcap-dev
-GO111MODULE=on go get -v github.com/projectdiscovery/naabu/v2/cmd/naabu
+go install -v github.com/projectdiscovery/naabu/v2/cmd/naabu@latest
 
 echo -e "\e[40;38;5;82m Naabu Installed \e[0m\n"
-#==============================================================================================
+#============================================================================
 echo -e "\e[40;38;5;82m Installing Nmap \e[0m\n"
 
-sudo apt-get install nmap -y 
+sudo apt-get install nmap -y
 
 echo -e "\e[40;38;5;82m Nmap installed \e[0m\n"
-
 #==============================================================================================
 echo -e "\e[40;38;5;82m Installing Dalfox \e[0m\n"
 
-GO111MODULE=on go get github.com/hahwul/dalfox/v2
+go install github.com/hahwul/dalfox/v2@latest
 
 echo -e "\e[40;38;5;82m Dalfox installed \e[0m\n"
 
@@ -280,7 +279,7 @@ wget https://gist.githubusercontent.com/six2dez/ffc2b14d283e8f8eff6ac83e20a3c4b4
 #==============================================================================================
 echo -e "\e[40;38;5;82m Installing Nuclei \e[0m\n"
 
-GO111MODULE=on go get -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei
+go install -v github.com/projectdiscovery/nuclei/v2/cmd/nuclei@latest
 
 echo -e "\e[40;38;5;82m Nuclei Installed \e[0m\n"
 


### PR DESCRIPTION
Updated : go1.17 (Required go 1.17 to run the latest version  Updated Tools)
Latest Updated tools:
Nuclei, Dalfox, dnsx, nabbu, Subfinder, httpx, notify, puredns, gauplus
---------------------------------------------------------------------------------

1. Issue with findomain with tools and Manually, can't able to run the cammand manually and with project-morya. 
sudo: findomain: command not found

Tried: 
mv findomain-linux /usr/local/bin/findomain
chmod 755 /usr/local/bin/findomain
strip -s /usr/local/bin/findomain
OR
git clone https://github.com/Edu4rdSHL/findomain.git
cd findomain
cargo build –-release
sudo cp target/release/findomain /usr/bin/

Error : Cargo edition = "2021"
Again Tried: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh 
Back to 1  Error : findomain: command not found


2. Still need to figue out it's running or not. I didn't find the repo on github  : 
go get github.com/cgboal/sonarsearch/crobat